### PR TITLE
Removed deprecated option from oneclient test mount.

### DIFF
--- a/playbooks/oneclient.yml
+++ b/playbooks/oneclient.yml
@@ -16,7 +16,7 @@
         name: /tmp/mntoc
         state: directory
     - name: Trying to mount oneclient 
-      command: "oneclient -H {{oneprovider}} -t {{access_token}} /tmp/mntoc -i -o allow_other --force-direct-io --force-fullblock-read -v 1 --rndrd-prefetch-cluster-window=12582912 --rndrd-prefetch-cluster-block-threshold=5  --cluster-prefetch-threshold-random --prefetch-mode-async --monitoring-type graphite --monitoring-level-full --provider-timeout=400  --monitoring-period 5 --graphite-url tcp://{{grafana_ip}}:2003 --graphite-namespace-prefix oneclient-op-ceph"
+      command: "oneclient -H {{oneprovider}} -t {{access_token}} /tmp/mntoc -i -o allow_other --force-direct-io --force-fullblock-read -v 1 --rndrd-prefetch-cluster-window=12582912 --rndrd-prefetch-cluster-block-threshold=5  --cluster-prefetch-threshold-random --monitoring-type graphite --monitoring-level-full --provider-timeout=400  --monitoring-period 5 --graphite-url tcp://{{grafana_ip}}:2003 --graphite-namespace-prefix oneclient-op-ceph"
       register: res
       until: res.rc == 0
       retries: 12


### PR DESCRIPTION
The async prefetch-mode is the default option in the new flag scheme.

Change-Id: I5acbe660033fa4106fc6be26a192b4de92b02143